### PR TITLE
Support Peer4commit project reference

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -56,7 +56,7 @@
           2014. Source code is available at #{link_to('github', 'https://github.com/sigmike/peer4commit', target: '_blank')},
           based on #{link_to "Tip4commit", "http://tip4commit.com/"}.
           You can
-          = link_to('support', 'http://tip4commit.com/projects/560')
+          = link_to('support', 'http://peer4commit.com/projects/1')
           its development.
     / /container
     /


### PR DESCRIPTION
on the http://peer4commit.com/projects/1 page there is the text in the footer that says
You can support its development
support links to the tip4commit page.. should link to your donation page do you think?
