### PR TITLE
Optimize the 'update_cache' method for User class to remove extra queries

### DIFF
--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -20,6 +20,10 @@ class Tip < ActiveRecord::Base
 
   scope :with_address,  -> { joins(:user).where('users.bitcoin_address IS NOT NULL') }
 
+  def paid?
+    !!sendmany_id
+  end
+
   def self.refund_unclaimed
     unclaimed.non_refunded.
     where('tips.created_at < ?', Time.now - 1.month).

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,9 +36,10 @@ class User < ActiveRecord::Base
   end
 
   def self.update_cache
-    find_each do |user|
-      user.update commits_count: user.tips.count
-      user.update withdrawn_amount: user.tips.paid.sum(:amount)
+    includes(:tips).find_each do |user|
+      user.update( commits_count: user.tips.size, 
+                   withdrawn_amount: user.tips.select(&:paid?).sum(:amount) )
     end
   end
+
 end


### PR DESCRIPTION
The current implementation of this method results in 2 queries per user for update along with 2 query per user to gather counts. Thats equal to 4 queries per 1 user.

The provided implementation eager-loads the 'tips' to avoid the 2*n queries for counts and also updates both the counts in a single update.

Hence, the number of queries run per user now is 1 with 1 additional query to eager_load all tips.
Thats around 300% reduced queries :smile:
