### PR TITLE
Handle destroy dependencies for Project, User and SendMany

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ActiveRecord::Base
-  has_many :deposits # todo: only confirmed deposits that have amount > paid_out
-  has_many :tips
+  has_many :deposits, dependent: :destroy # todo: only confirmed deposits that have amount > paid_out
+  has_many :tips, dependent: :destroy 
 
   validates :full_name, uniqueness: true, presence: true
   validates :github_id, uniqueness: true, presence: true

--- a/app/models/sendmany.rb
+++ b/app/models/sendmany.rb
@@ -1,6 +1,6 @@
 class Sendmany < ActiveRecord::Base
   belongs_to :project
-  has_many :tips
+  has_many :tips, dependent: :destroy
 
   def send_transaction
     return if txid || is_error

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ActiveRecord::Base
 
   validates :bitcoin_address, :bitcoin_address => true
 
-  has_many :tips
+  has_many :tips, dependent: :destroy
 
   def github_url
     "https://github.com/#{nickname}"


### PR DESCRIPTION
Adding 'dependent: :destroy' option to models so that destroying any model object does not leave the database in an inconsistent state.
