### PR TITLE
minor optimisation.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,19 +10,15 @@ class User < ActiveRecord::Base
 
   has_many :tips
 
+  # Callbacks
+  before_create :generate_login_token!, unless: :login_token?
+
   def github_url
     "https://github.com/#{nickname}"
   end
 
   def balance
-  	tips.unpaid.sum(:amount)
-  end
-
-  after_create :generate_login_token!
-  def generate_login_token!
-    if login_token.blank?
-      self.update login_token: SecureRandom.urlsafe_base64
-    end
+    tips.unpaid.sum(:amount)
   end
 
   def full_name
@@ -43,6 +39,15 @@ class User < ActiveRecord::Base
       user.commits_count = commits_counts[user.id] || 0
       user.withdrawn_amount = paid_sums[user.id] || 0
       user.save
+    end
+  end
+
+  private
+
+  def generate_login_token!
+    loop do
+      self.login_token = SecureRandom.urlsafe_base64
+      break login_token unless User.exists?(login_token: login_token)
     end
   end
 


### PR DESCRIPTION
1. optimize login_token generation.

Whenever we are generating the login_token for a user, currently, it is firing 2 queries to the DB, 1 for the 'create' and 1 for the 'update' login_token statement.

If we set the login_token in a :before_create callback we would still have the update within the transaction plus the login_token would get saved in the 'create' statement itself.
1. create unique login token for each user.

We were setting login token using SecureRandom.urlsafe_base64 before user's creation and login token is unique for each user, so we must ensure that it should be unique for all users.
