### PR TITLE
Stop PPCoin addresses overflowing the panel

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -28,3 +28,4 @@
 // Example:
 // @linkColor: #ff0000;
 .qrcode {text-align:center}
+.panel-body {overflow:auto}


### PR DESCRIPTION
This was a problem on the Project Sponsors panel as demonstrated at http://peer4commit.com/projects/1. This change makes the entire block gain a scroll bar if necessary, so that the entire value is still accessible, but it is not in the way, overflowing onto the top of the main content.

This was mainly an issue for a viewport width in the range 992–1199px, though with a significant percentage of wider characters (e.g. lots of W's, not many i's) it could still appear outside that range.
