### PR TITLE
Project collaborators can set a free amount on undecided tips

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,7 +51,7 @@ module ApplicationHelper
     flash.each do |type, message|
       alert_type = case type
         when :notice then :success
-        when :alert  then :danger
+        when :alert, :error then :danger
       end
       html << content_tag(:div, message, class: "flash-message text-center alert alert-#{alert_type}")
     end

--- a/app/views/projects/decide_tip_amounts.html.haml
+++ b/app/views/projects/decide_tip_amounts.html.haml
@@ -1,3 +1,6 @@
+%h1 Decide tip amounts
+%p
+  Project balance: #{btc_human @project.available_amount}
 = bootstrap_form_for @project, url: decide_tip_amounts_project_path(@project) do |f|
   %table.table.table-hover.decide-tip-amounts-table
     %thead
@@ -5,23 +8,21 @@
         %th Commit
         %th Author
         %th Message
-        %th Tip (relative to the project balance)
+        %th Percentage of balance
+        %th Free amount
     %tbody
-      = f.fields_for(:tips, @project.tips.undecided) do |tip_fields|
+      = f.fields_for(:tips, @project.tips.select(&:was_undecided?)) do |tip_fields|
         = tip_fields.hidden_field :id
         - tip = tip_fields.object
         %tr
           %td= link_to commit_tag(tip.commit), tip.commit_url
           %td= tip.user.nickname
           %td= simple_format tip.commit_message
-          %td
-            = tip_fields.radio_button :amount_percentage,    "", inline: true, label: "Undecided"
-            = tip_fields.radio_button :amount_percentage,   "0", inline: true, label: "Free: 0%"
-            = tip_fields.radio_button :amount_percentage, "0.1", inline: true, label: "Tiny: 0.1%"
-            = tip_fields.radio_button :amount_percentage, "0.5", inline: true, label: "Small: 0.5%"
-            = tip_fields.radio_button :amount_percentage,   "1", inline: true, label: "Normal: 1%"
-            = tip_fields.radio_button :amount_percentage,   "2", inline: true, label: "Big: 2%"
-            = tip_fields.radio_button :amount_percentage,   "5", inline: true, label: "Huge: 5%"
+          %td.col-sm-2
+            - options = [["Free: 0%", "0"], ["Tiny: 0.1%", "0.1"], ["Small: 0.5%", "0.5"], ["Normal: 1%", "1"], ["Big: 2%", "2"], ["Huge: 5%", "5"]]
+            = tip_fields.select :decided_amount_percentage, options, hide_label: true, include_blank: true
+          %td.col-sm-2
+            = tip_fields.text_field :decided_free_amount, inline: true, hide_label: true, append: "PPC"
 
   .text-center
     = f.submit 'Send the selected tip amounts'

--- a/features/step_definitions/tip_modifier_interface.rb
+++ b/features/step_definitions/tip_modifier_interface.rb
@@ -1,13 +1,19 @@
 When(/^I choose the amount "(.*?)" on commit "(.*?)"$/) do |arg1, arg2|
   within find(".decide-tip-amounts-table tbody tr", text: arg2) do
-    choose arg1
+    select arg1
+  end
+end
+
+When(/^I fill the free amount with "(.*?)" on commit "(.*?)"$/) do |arg1, arg2|
+  within find(".decide-tip-amounts-table tbody tr", text: arg2) do
+    fill_in "Decided free amount", with: arg1
   end
 end
 
 When(/^I choose the amount "(.*?)" on all commits$/) do |arg1|
   all(".decide-tip-amounts-table tbody tr").each do |tr|
     within tr do
-      choose arg1
+      select arg1
     end
   end
 end
@@ -51,7 +57,7 @@ Given(/^I send a forged request to set the amount of the first undecided tip of 
       tips_attributes: {
         "0" => {
           id: tip.id,
-          amount_percentage: "5",
+          decided_amount_percentage: "5",
         },
       },
     },
@@ -69,7 +75,7 @@ When(/^I send a forged request to change the percentage of commit "(.*?)" on pro
       tips_attributes: {
         "0" => {
           id: tip.id,
-          amount_percentage: arg3,
+          decided_amount_percentage: arg3,
         },
       },
     },
@@ -81,4 +87,3 @@ end
 Then(/^the project should have (\d+) undecided tips$/) do |arg1|
   @project.tips.undecided.size.should eq(arg1.to_i)
 end
-

--- a/features/tip_modifier_interface.feature
+++ b/features/tip_modifier_interface.feature
@@ -122,3 +122,45 @@ Feature: A project collaborator can change the tips of commits
       | seldon  | there should be a tip of "25" for commit "BBB"      |
       | bad guy | the tip amount for commit "BBB" should be undecided |
 
+  Scenario: A collaborator sends a free amount as tip
+    Given the project holds tips
+    And the new commits are read
+    And I'm logged in as "seldon"
+    And I go to the project page
+    And I click on "Decide tip amounts"
+    When I fill the free amount with "10" on commit "BBB"
+    And I click on "Send the selected tip amounts"
+    Then there should be a tip of "10" for commit "BBB"
+    And the tip amount for commit "CCC" should be undecided
+
+  Scenario: A collaborator sends too big free amounts
+    Given the project holds tips
+    And the new commits are read
+    And I'm logged in as "seldon"
+    And I go to the project page
+    And I click on "Decide tip amounts"
+    When I choose the amount "Tiny: 0.1%" on commit "BBB"
+    And I fill the free amount with "499.500001" on commit "CCC"
+    And I click on "Send the selected tip amounts"
+    Then I should see "The project has insufficient funds"
+    And the tip amount for commit "BBB" should be undecided
+    And the tip amount for commit "CCC" should be undecided
+
+    When I fill the free amount with "499.5" on commit "CCC"
+    And I click on "Send the selected tip amounts"
+    Then there should be a tip of "0.5" for commit "BBB"
+    And there should be a tip of "499.5" for commit "CCC"
+    And the project balance should be "0"
+
+  Scenario: A collaborator changes the amount of an already decided tip
+    Given the project holds tips
+    And the new commits are read
+    And I'm logged in as "seldon"
+    And I go to the project page
+    And I click on "Decide tip amounts"
+    When I fill the free amount with "10" on commit "BBB"
+    And I click on "Send the selected tip amounts"
+    Then there should be a tip of "10" for commit "BBB"
+    And the tip amount for commit "CCC" should be undecided
+    And I send a forged request to change the percentage of commit "BBB" on project "a" to "5"
+    Then there should be a tip of "10" for commit "BBB"


### PR DESCRIPTION
In addition to the percentages, the project collaborators can set a free amount of peercoin per commit.
