### PR TITLE
add sign-up button to header (issue #99)

### DIFF
--- a/app/assets/stylesheets/home.css.sass
+++ b/app/assets/stylesheets/home.css.sass
@@ -70,7 +70,7 @@ h1:first-child
     a
       +inline-block(middle)
       margin-left: 6px
-  
+
 #main-menu
   +inline-block(middle)
 
@@ -113,7 +113,7 @@ h3
   +verdana
   color: #599400
   font-size: 18px
-  
+
 h4
   +verdana
   color: #363636
@@ -193,3 +193,7 @@ h4
   td, th
     &.actions, &.amount
       text-align: right
+
+#sign-in-form , #sign-up-form
+  h2
+    font-size: 24px

--- a/app/assets/stylesheets/projects.css.sass
+++ b/app/assets/stylesheets/projects.css.sass
@@ -13,3 +13,13 @@
 .donor-list
   .amount
     text-align: right
+
+#session-menu
+  color: #000
+  span
+    position: relative
+    left:          4px
+
+#sign-up-form
+  div
+    text-align: center

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,9 +1,21 @@
-= twitter_bootstrap_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-devise'}) do |f|
-  %h2 Sign up
-  = devise_error_messages!
-  = f.email_field :email, :autofocus => true
-  = f.password_field :password
-  = f.password_field :password_confirmation
-  = f.submit "Sign up"
-  %p
-    = render "devise/shared/links"
+#sign-up-form
+  .row
+    .col-md-4
+      %h2 Sign up
+      = twitter_bootstrap_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-devise'}) do |f|
+        = devise_error_messages!
+        = hidden_field_tag :return_url, params[:return_url]
+        = f.email_field :email, :autofocus => true
+        = f.password_field :password
+        = f.password_field :password_confirmation
+        = f.submit "Sign up"
+      %p
+        Already a member?
+        = render "devise/shared/links"
+    .col-md-4
+      %h2 or
+    .col-md-4
+      %h2 Instant sign in
+      - if devise_mapping.omniauthable?
+        - resource_class.omniauth_providers.each do |provider|
+          = link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider, origin: params[:return_url]), class: "btn btn-primary"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,7 +1,7 @@
 #sign-in-form
   .row
     .col-md-4
-      %h4 Sign in with your email
+      %h2 Sign in with your email
       = twitter_bootstrap_form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
         = hidden_field_tag :return_url, params[:return_url]
         = f.email_field :email, :autofocus => true
@@ -12,9 +12,9 @@
         = f.submit "Sign in", class: 'btn btn-primary btn-block'
     .col-md-4
       - if devise_mapping.omniauthable?
-        %h4 Sign in with a provider
+        %h2 Sign in with a provider
         - resource_class.omniauth_providers.each do |provider|
           = link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider, origin: params[:return_url]), class: "btn btn-primary btn-block"
     .col-md-4
-      %h4 Other options
+      %h2 Other options
       = render "devise/shared/links"

--- a/app/views/devise/shared/_links.haml
+++ b/app/views/devise/shared/_links.haml
@@ -1,8 +1,12 @@
+- is_devise_page = %w{sessions registrations confirmations passwords}.include? controller_name
+- q = request.query_string
+- params = (q.match /return_url=/)? "?#{q}" : (is_devise_page)? "" : "?return_url=#{request.url}"
+
 - if controller_name != 'sessions'
-  = link_to "Sign in", new_session_path(resource_name)
+  = link_to "Sign in", "#{new_session_path(resource_name)}#{params}"
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "Sign up", "#{new_registration_path(resource_name)}#{params}"
   %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
   = link_to "Forgot your password?", new_password_path(resource_name)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     %meta{content: "", name: "description"}/
     %meta{content: "", name: "author"}/
     %link{href: image_path("ppcoin.png"), rel: "shortcut icon"}/
-    
+
     %title= content_for?(:title) ? yield(:title) : "Peer4commit"
 
     %meta{name: 'description', content: (content_for?(:title) ? yield(:title) : "Donate peercoins to open source projects or make commits and get tips for it.")}
@@ -22,7 +22,7 @@
       %script{:src => "https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"}
 
 
-    
+
     = csrf_meta_tags
   %body
     :javascript
@@ -38,9 +38,17 @@
         #session-menu
           - if current_user
             = link_to current_user.full_name, edit_registration_path(current_user), class: "edit-profile-link"
-            = link_to 'Sign Out', destroy_user_session_path, method: :delete, class: "btn btn-default"
+            = link_to "Sign out", destroy_user_session_path, method: :delete, class: "btn btn-default"
           - else
-            = link_to "Sign in", new_user_session_path(return_url: request.url), class: "btn btn-default"
+            - is_devise_page = %w{sessions registrations confirmations passwords}.include? controller_name
+            - q      = request.query_string
+            - params = (q.match /return_url=/)? "?#{q}" : (is_devise_page)? "" : "?return_url=#{request.url}"
+            - if controller_name != 'registrations'
+              = link_to "Sign up", "#{new_user_registration_path}#{params}", class: "btn btn-default"
+            - unless is_devise_page
+              %span or
+            - if controller_name != 'sessions'
+              = link_to "Sign in", "#{new_user_session_path}#{params}", class: "btn btn-default"
         %a#main-logo{href: root_path}
           %h3 Peer4commit
         = render 'common/menu'


### PR DESCRIPTION
- implements feature request #99
- header filters 'sign_up' and 'sign_in' links based on controller
- added provider login buttons to sign-up page
- made all sign-in and sign-up links pass redirection url
