### PR TITLE
initial support to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM opensuse
+RUN zypper -n install -t pattern  devel_basis 
+RUN zypper -n install sqlite3-devel nodejs ruby ruby-devel git postgresql-devel mysql-devel libmysqlclient-devel gcc-c++ vim
+RUN mkdir /peer4commit
+WORKDIR /peer4commit
+RUN gem install bundler --no-format-executable
+# ADD . /peer4commit
+# RUN bundler install

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ git clone git@github.com:sigmike/peer4commit.git
 cd peer4commit
 ```
 
+or using docker:
+```
+cd $DIR # where dir is the git cloned repository
+docker build -t <username>/peer4commit .
+docker run -ti -v $PWD:/peer4commit <username>/peer4commit /bin/bash
+then you will be in the container, in the peer4commit directory
+where you can bundle install and change files
+```
+
 * Install the sqlite3 development libraries
 
 * Install the gems (without the production gems):


### PR DESCRIPTION
Hi, I added it as initial support, but we can extend it to have a full deployment in a container. However for now you are able to set the development environment with two commands as described in the README. Please feedback it!

````
docker build ...
docker run ...
````